### PR TITLE
Add Default 'Submitted' Status to Borrow Create Route and Update Schema Enum and updated /create to include user requests 

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -25,7 +25,7 @@ model borrow {
   borrow_date             DateTime                       @db.Date
   return_date             DateTime?                      @db.Date
   borrow_status           borrow_borrow_status
-  device_return_condition borrow_device_return_condition
+  device_return_condition borrow_device_return_condition @default(Submitted)
   user_location           String?                        @db.VarChar(255)
   device_location         String?                        @db.VarChar(255)
   reason_for_borrow       borrow_reason_for_borrow
@@ -73,6 +73,7 @@ model user {
 }
 
 enum borrow_borrow_status {
+  Submitted
   Scheduled
   Canceled
   Checked_out @map("Checked out")

--- a/routes/borrow_routes.js
+++ b/routes/borrow_routes.js
@@ -34,6 +34,7 @@ router.post("/create", ensureAnyAuth, async (req, res) => {
     device_return_condition = null; // Ignore user input)
   } else {
     borrow_status = borrow_status || "Submitted"; 
+    device_return_condition = device_return_condition || null;  // Admins can set or leave null
   }
 
   if (!user_id || !device_id || !borrow_date || !reason_for_borrow) {


### PR DESCRIPTION
This PR introduces the following updates:

- **Routes:**
  - Modified POST /create in borrow_routes.js to assign "Submitted" as the default borrow_status if not explicitly set.
  - Ensured that regular users can submit borrow requests without the ability to manually setting the status or condition. 

- **Prisma Schema:**
  - Updated borrow_status enum in schema.prisma to include "Submitted" to align with route logic and business rules.