### PR TITLE
Added proper fields for device and paging

### DIFF
--- a/app.js
+++ b/app.js
@@ -27,16 +27,20 @@ app.get("/api/me", ensureAnyAuth, async (req, res) => {
         where: { user_id: req.id },
       });
       res.json({
-        id: user.user_id,
-        email: user.email,
-        first_name: user.first_name,
-        last_name: user.last_name,
-        phone: user.phone,
-        street_address: user.street_address,
-        city: user.city,
-        state: user.state,
-        zip_code: user.zip_code,
-        dob: user.dob,
+        message: "User login successful",
+        loginType: "user",
+        user: {
+          id: user.user_id,
+          email: user.email,
+          first_name: user.first_name,
+          last_name: user.last_name,
+          phone: user.phone,
+          street_address: user.street_address,
+          city: user.city,
+          state: user.state,
+          zip_code: user.zip_code,
+          dob: user.dob,
+        }
       });
       return;
     }
@@ -46,7 +50,8 @@ app.get("/api/me", ensureAnyAuth, async (req, res) => {
     });
 
     res.json({
-      message: "Login successful",
+      message: "Admin login successful",
+      loginType: "admin",
       admin: {
         admin_id: admin.admin_id,
         email: admin.email,

--- a/dummy_data.sql
+++ b/dummy_data.sql
@@ -1,0 +1,40 @@
+USE oc_devices;
+
+INSERT INTO location (location_id, location_nickname, street_address, city, state, zip_code) VALUES
+(1, 'Callahan Neighborhood Center', '101 N Parramore Ave #1713', 'Orlando', 'FL', '32801'),
+(2, 'Hankins Park Neighborhood Center', '1340 Lake Park Ct', 'Orlando', 'FL', '32805'),
+(3, 'Northwest Neighborhood Center', '3955 W D Judge Dr', 'Orlando', 'FL', '32808'),
+(4, 'Rosemont Neighborhood Center', '4872 Rose Bay Dr', 'Orlando', 'FL', '32808'),
+(5, 'Smith Neighborhood Center', '1723 Bruton Blvd', 'Orlando', 'FL', '32805'),
+(6, 'Citrus Square Neighborhood Center', '5624 Hickey Drive', 'Orlando', 'FL', '32822'),
+(7, 'Engelwood Neighborhood Center', '6123 La Costa Dr #2931', 'Orlando', 'FL', '32807'),
+(8, 'Jackson Neighborhood Center', '1002 Carter St', 'Orlando', 'FL', '32805'),
+(9, 'L Claudia Allen Senior Center', '1840 Mable Butler Ave #4261', 'Orlando', 'FL', '32805'),
+(10, 'Grand Avenue Neighborhood Center', '800 Grand St', 'Orlando', 'FL', '32805'),
+(11, 'Ivey Lane Neighborhood Center', '5151 Raleigh St Ste C', 'Orlando', 'FL', '32811'),
+(12, 'Langford Park Neighborhood Center', '1808 E Central Blvd', 'Orlando', 'FL', '32803'),
+(13, 'Rock Lake Neighborhood Center', '440 N Tampa Ave', 'Orlando', 'FL', '32805'),
+(14, 'Wadeview Neighborhood Center', '2177 S Summerlin Ave', 'Orlando', 'FL', '32806'),
+(15, 'Dover Shores Neighborhood Center', '1400 Gaston Foster Rd', 'Orlando', 'FL', '32812'),
+(16, 'RISE employment training facility', '1221 West Colonial Drive', 'Orlando', 'FL', '32804'),
+(17, 'Hispanic Office for Local Assistance', '595 North Primrose Drive', 'Orlando', 'FL', '32803');
+
+INSERT INTO user (user_id, email, hash, salt, first_name, last_name, phone, street_address, city, state, zip_code, dob) VALUES
+(2, 'bob.johnson2@example.com', 'hash2', 'salt2', 'Bob', 'Johnson', '555-0002', '456 Example St', 'Orlando', 'FL', '32801', '1989-08-23'),
+(3, 'charlie.brown3@example.com', 'hash3', 'salt3', 'Charlie', 'Brown', '555-0003', '789 Example St', 'Orlando', 'FL', '32801', '1995-12-01'),
+(4, 'diana.jones4@example.com', 'hash4', 'salt4', 'Diana', 'Jones', '555-0004', '101 Example Blvd', 'Orlando', 'FL', '32801', '1991-03-10'),
+(5, 'eli.garcia5@example.com', 'hash5', 'salt5', 'Eli', 'Garcia', '555-0005', '234 Sample Way', 'Orlando', 'FL', '32801', '1994-11-30');
+
+INSERT INTO device (device_id, brand, make, model, type, serial_number, location_id) VALUES
+(1, 'Dell', 'Inspiron', '15', 'Laptop', 'S12345', 1),
+(2, 'HP', 'Pavilion', '13', 'Laptop', 'S12346', 2),
+(3, 'Apple', 'MacBook', 'Pro', 'Laptop', 'S12347', 3),
+(4, 'Lenovo', 'ThinkPad', 'X1', 'Laptop', 'S12348', 4),
+(5, 'Asus', 'VivoBook', 'Air', 'Laptop', 'S12349', 5);
+
+INSERT INTO borrow (borrow_id, user_id, device_id, borrow_date, return_date, borrow_status, device_return_condition, user_location, device_location, reason_for_borrow) VALUES
+(1, 1, 1, '2024-06-01', '2024-06-10', 'Checked in', 'Good', 'Callahan Neighborhood Center', 'Callahan Neighborhood Center', 'Job Search'),
+(2, 2, 2, '2024-06-15', NULL, 'Checked out', 'Good', 'Hankins Park Neighborhood Center', 'Hankins Park Neighborhood Center', 'Training'),
+(3, 3, 3, '2024-05-20', '2024-06-01', 'Checked in', 'Fair', 'Northwest Neighborhood Center', 'Northwest Neighborhood Center', 'School'),
+(4, 4, 4, '2024-07-01', NULL, 'Submitted', 'Good', 'Rosemont Neighborhood Center', 'Rosemont Neighborhood Center', 'Other'),
+(5, 5, 5, '2024-06-20', NULL, 'Scheduled', 'Good', 'Smith Neighborhood Center', 'Smith Neighborhood Center', 'Job Search');

--- a/models/device_model.js
+++ b/models/device_model.js
@@ -1,4 +1,0 @@
-const prisma = require("../config/db");
-
-const get_all_devices = async () => {
-};

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -19,18 +19,18 @@ model admin {
 }
 
 model borrow {
-  borrow_id               Int                            @id @default(autoincrement())
+  borrow_id               Int                             @id @default(autoincrement())
   user_id                 Int
   device_id               Int
-  borrow_date             DateTime                       @db.Date
-  return_date             DateTime?                      @db.Date
-  borrow_status           borrow_borrow_status           @default(Submitted)
-  device_return_condition borrow_device_return_condition @default(Good)
-  user_location           String?                        @db.VarChar(255)
-  device_location         String?                        @db.VarChar(255)
+  borrow_date             DateTime                        @db.Date
+  return_date             DateTime?                       @db.Date
+  borrow_status           borrow_borrow_status            @default(Submitted)
+  device_return_condition borrow_device_return_condition? @default(Good)
+  user_location           String?                         @db.VarChar(255)
+  device_location         String?                         @db.VarChar(255)
   reason_for_borrow       borrow_reason_for_borrow
-  user                    user                           @relation(fields: [user_id], references: [user_id], onUpdate: Restrict, map: "borrow_ibfk_1")
-  device                  device                         @relation(fields: [device_id], references: [device_id], onUpdate: Restrict, map: "borrow_ibfk_2")
+  user                    user                            @relation(fields: [user_id], references: [user_id], onUpdate: Restrict, map: "borrow_ibfk_1")
+  device                  device                          @relation(fields: [device_id], references: [device_id], onUpdate: Restrict, map: "borrow_ibfk_2")
 
   @@index([device_id], map: "device_id")
   @@index([user_id], map: "user_id")
@@ -39,6 +39,9 @@ model borrow {
 model device {
   device_id     Int      @id @default(autoincrement())
   brand         String?  @db.VarChar(255)
+  make          String?  @db.VarChar(255)
+  model         String?  @db.VarChar(255)
+  type          String?  @db.VarChar(255)
   serial_number String   @db.VarChar(255)
   location_id   Int
   borrow        borrow[]
@@ -48,12 +51,13 @@ model device {
 }
 
 model location {
-  location_id    Int      @id @default(autoincrement())
-  street_address String   @db.VarChar(255)
-  city           String   @db.VarChar(255)
-  state          String   @db.Char(2)
-  zip_code       String   @db.Char(5)
-  device         device[]
+  location_nickname String?
+  location_id       Int      @id @default(autoincrement())
+  street_address    String   @db.VarChar(255)
+  city              String   @db.VarChar(255)
+  state             String   @db.Char(2)
+  zip_code          String   @db.Char(5)
+  device            device[]
 }
 
 model user {
@@ -75,7 +79,7 @@ model user {
 enum borrow_borrow_status {
   Submitted
   Scheduled
-  Canceled
+  Cancelled
   Checked_out @map("Checked out")
   Checked_in  @map("Checked in")
   Late

--- a/routes/location_routes.js
+++ b/routes/location_routes.js
@@ -1,83 +1,95 @@
-const {json, Router} = require("express");
+const { json, Router } = require("express");
 const prisma = require("../config/db");
-const {ensureAdminAuth, ensureAnyAuth} = require("../helpers/middleware");
+const { ensureAdminAuth, ensureAnyAuth } = require("../helpers/middleware");
 
 const router = Router();
 router.use(json());
 
 router.get("/getall", ensureAnyAuth, async (req, res) => {
-    try {
-        const locations = await prisma.location.findMany({
-            include: { device: true },
-        });
-        res.send(locations);
-    } catch (err) {
-        res.status(500).send("Failed to retrieve locations.");
-        console.error(err);
+  try {
+    const { page, pageSize } = req.params;
+
+    const prismaConfig = {
+      include: { device: true },
+    };
+
+    if (pageSize && typeof pageSize == "number") {
+      prismaConfig.take = pageSize;
+
+      if (page && typeof page == "number") {
+        prismaConfig.skip = (page - 1) * pageSize;
+      }
     }
+
+    const locations = await prisma.location.findMany(prismaConfig);
+    res.send(locations);
+  } catch (err) {
+    res.status(500).send("Failed to retrieve locations.");
+    console.error(err);
+  }
 });
 
 router.get("/get/:locationId", ensureAdminAuth, async (req, res) => {
-    const locationId = parseInt(req.params.locationId);
+  const locationId = parseInt(req.params.locationId);
 
-    if (!locationId) {
-        res.status(400).send("Bad request.");
-        return;
+  if (!locationId) {
+    res.status(400).send("Bad request.");
+    return;
+  }
+
+  try {
+    const location = await prisma.location.findUnique({
+      where: { location_id: locationId },
+      include: { device: true },
+    });
+
+    if (!location) {
+      res.status(404).send("Location not found.");
+      return;
     }
-
-    try {
-        const location = await prisma.location.findUnique({
-            where: { location_id: locationId},
-            include: { device: true},
-        });
-
-        if (!location) {
-            res.status(404).send("Location not found.");
-            return;
-        }
-        res.send(location);
-    } catch (err) {
-        res.status(500).send("Error retrieving location.");
-        console.error(err);
-    }
+    res.send(location);
+  } catch (err) {
+    res.status(500).send("Error retrieving location.");
+    console.error(err);
+  }
 });
 
 router.post("/create", ensureAdminAuth, async (req, res) => {
-    const { street_address, city, state, zip_code } = req.body;
+  const { street_address, city, state, zip_code } = req.body;
 
-    if (!street_address || !city || !state || !zip_code) {
-        res.status(400).send("Missing required fields.");
-        return;
-    }
+  if (!street_address || !city || !state || !zip_code) {
+    res.status(400).send("Missing required fields.");
+    return;
+  }
 
-    try {
-        const newLocation = await prisma.location.create({
-            data: { street_address, city, state, zip_code }
-        });
-        res.status(201).send(newLocation);
-    } catch (err) {
-        res.status(400).send("Could not create location.");
-        console.error(err);
-    }
+  try {
+    const newLocation = await prisma.location.create({
+      data: { street_address, city, state, zip_code }
+    });
+    res.status(201).send(newLocation);
+  } catch (err) {
+    res.status(400).send("Could not create location.");
+    console.error(err);
+  }
 });
 
 router.delete("/delete/:locationId", ensureAdminAuth, async (req, res) => {
-    const locationId = parseInt(req.params.locationId);
+  const locationId = parseInt(req.params.locationId);
 
-    if (!locationId) {
-        res.status(400).send("Bad request.");
-        return;
-    }
+  if (!locationId) {
+    res.status(400).send("Bad request.");
+    return;
+  }
 
-    try {
-        await prisma.location.delete({
-            where: {location_id: locationId}
-        });
-        res.send("Location deleted!");
-    } catch (err) {
-        res.status(500).send("Failed to delete location.");
-        console.error(err);
-    }
+  try {
+    await prisma.location.delete({
+      where: { location_id: locationId }
+    });
+    res.send("Location deleted!");
+  } catch (err) {
+    res.status(500).send("Failed to delete location.");
+    console.error(err);
+  }
 });
 
 module.exports = router;

--- a/routes/user_routes.js
+++ b/routes/user_routes.js
@@ -227,7 +227,9 @@ router.delete("/delete/:userId", ensureAnyAuth, async (req, res) => {
 });
 
 router.get("/getall", ensureAdminAuth, async (req, res) => {
-  const users = await prisma.user.findMany({
+  const { page, pageSize } = req.params;
+
+  const prismaConfig = {
     select: {
       user_id: true,
       email: true,
@@ -240,7 +242,17 @@ router.get("/getall", ensureAdminAuth, async (req, res) => {
       zip_code: true,
       dob: true,
     },
-  });
+  };
+
+  if (pageSize && typeof pageSize == "number") {
+    prismaConfig.take = pageSize;
+
+    if (page && typeof page == "number") {
+      prismaConfig.skip = (page - 1) * pageSize;
+    }
+  }
+
+  const users = await prisma.user.findMany(prismaConfig);
 
   res.send(users);
 });


### PR DESCRIPTION
- `/api/me` returns data in a way that makes more sense
- Added `dummy_data` script. May need to be edited if your database name is different though. Should git ignore it eventually
- Added needed fields to `device`
- Added needed fields to `borrow`
- Added nicknames (optional) for locations
- Fixed a type in status "Canceled" to "Cancelled"
- Create device route actually works now
- You can optionally set `page` and `pageSize` url params on all `/getall` routes. I.e. `localhost:3001/api/user/getall?page=2&pageSize=10`
- Other small fixes for things that totally broke certain routes.