### PR TITLE
Admin profile reset update

### DIFF
--- a/app.js
+++ b/app.js
@@ -23,7 +23,7 @@ app.use("/api/devices", deviceRoutes);
 app.use("/api/locations", locationRoutes);
 app.use("/api/borrow", borrowRoutes);
 app.use("/api/zipcode", zipcodeRoutes);
-app.use("/auth", authRoutes);
+app.use("/api/auth", authRoutes);
 app.get("/api/me", ensureAnyAuth, async (req, res) => {
   try {
     if (req.role === "user") {

--- a/example.env
+++ b/example.env
@@ -19,3 +19,6 @@ RESET_PASSWORD=your_app_password_here
 
 # Frontend app's base URL for password reset page
 FRONTEND_URL=http://localhost:3000
+
+# For admin panel (or wherever admin reset should land)
+ADMIN_FRONTEND_URL=http://localhost:3001

--- a/example.env
+++ b/example.env
@@ -21,4 +21,5 @@ RESET_PASSWORD=your_app_password_here
 FRONTEND_URL=http://localhost:3000
 
 # For admin panel (or wherever admin reset should land)
-ADMIN_FRONTEND_URL=http://localhost:3001
+ADMIN_FRONTEND_URL=http://localhost:3000
+

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -10,7 +10,7 @@ datasource db {
 
 model admin {
   admin_id   Int      @id @default(autoincrement())
-  email      String   @db.VarChar(255)
+  email      String   @unique @db.VarChar(255)
   hash       String   @db.VarChar(255)
   salt       String   @db.VarChar(255)
   first_name String   @db.VarChar(255)
@@ -63,22 +63,21 @@ model location {
 }
 
 model user {
-  user_id        Int             @id @default(autoincrement())
-  email          String          @unique @db.VarChar(255)
-  hash           String          @db.VarChar(255)
-  salt           String          @db.VarChar(255)
-  first_name     String          @db.VarChar(255)
-  last_name      String          @db.VarChar(255)
-  phone          String?         @db.VarChar(255)
-  street_address String          @db.VarChar(255)
-  city           String          @db.VarChar(255)
-  state          String          @db.Char(2)
-  zip_code       String          @db.Char(5)
-  dob            DateTime        @db.Date
-  is_verified    Boolean         @default(false)
-  created        DateTime        @default(now())
+  user_id        Int      @id @default(autoincrement())
+  email          String   @unique @db.VarChar(255)
+  hash           String   @db.VarChar(255)
+  salt           String   @db.VarChar(255)
+  first_name     String   @db.VarChar(255)
+  last_name      String   @db.VarChar(255)
+  phone          String?  @db.VarChar(255)
+  street_address String   @db.VarChar(255)
+  city           String   @db.VarChar(255)
+  state          String   @db.Char(2)
+  zip_code       String   @db.Char(5)
+  dob            DateTime @db.Date
+  is_verified    Boolean  @default(false)
+  created        DateTime @default(now())
   borrow         borrow[]
-  passwordResets passwordReset[]
 }
 
 model passwordReset {
@@ -87,7 +86,7 @@ model passwordReset {
   token      String   @unique @db.VarChar(255)
   expires_at DateTime
   used       Boolean  @default(false)
-  role       String   // "user" or "admin"
+  role       String   @default("user") @db.VarChar(255)
 
   @@map("password_resets")
 }

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -87,9 +87,9 @@ model passwordReset {
   token      String   @unique @db.VarChar(255)
   expires_at DateTime
   used       Boolean  @default(false)
-  user       user     @relation(fields: [user_id], references: [user_id], onDelete: Cascade)
+  role       String   // "user" or "admin"
 
-  @@map("password_resets") // Optional: maps to MySQL table name
+  @@map("password_resets")
 }
 
 enum borrow_borrow_status {


### PR DESCRIPTION
Summary of Changes:

Added shared /auth/reset-password POST route to handle both user and admin password resets using token.

Modified passwordReset table to include:
    - role field to distinguish between users and admins 
    - used` flag to prevent token reuse

Updated logic to:
    - Identify role from token
    - Update either user or admin table respectively 
    - Mark token as used after successful reset

Changes Made:

- Added POST /auth/admin-request-reset endpoint
- Integrated unique token generation with expiration
- Configured email sending via Nodemailer for admin reset
- Implemented generic response to avoid account enumeration
- Reused and extended the existing transporter and .env config
- Ensured only users with role: "admin" can access this endpoint

Notes:

Admins may have a different FRONTEND_URL for password reset depending on the app structure, just as standard users had a specific one.